### PR TITLE
package.json babel__core @types ^7.1.12

### DIFF
--- a/lib/templates/plugin-structure-mongoose/package.json
+++ b/lib/templates/plugin-structure-mongoose/package.json
@@ -21,6 +21,7 @@
     "mongoose": "5.10.0"
   },
   "devDependencies": {
+    "@types/babel__core": "^7.1.12",
     "@types/cors": "^2.8.6",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.5",


### PR DESCRIPTION
28 issues spam without it on a vanilla generation. This pull request fixes the following open issue: https://github.com/open-devs/fastify-typescript-generator/issues/17